### PR TITLE
docs(commits): add license section

### DIFF
--- a/conventional-commits.md
+++ b/conventional-commits.md
@@ -186,3 +186,19 @@ Prefer using `refactor` for more complex changes, including those that may intro
 ### Bibliography
   - [Angular convention](https://github.com/angular/angular/blob/88fbc06/CONTRIBUTING.md#-commit-message-guidelines) (88fbc06)
   - Chris Beams. [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/)
+
+### License
+
+   Copyright 2020-2022 Flowing Code. S.A.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   
+   You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+


### PR DESCRIPTION
This repository is licensed under the Apache License v2.0, but the license is not explicitly mentioned in the Commit Message Guidelines.