### PR TITLE
docs(code-style): update maven plugin coordinates

### DIFF
--- a/code-style.md
+++ b/code-style.md
@@ -1,4 +1,4 @@
-## Flowing Code Style Guide / 1.0.1
+## Flowing Code Style Guide / 1.0.2
 
 ### Java
 
@@ -7,6 +7,6 @@ Apply the [Google Java Style Guide](https://google.github.io/styleguide/javaguid
 * Eclipse: download the [eclipse-java-google-style](https://github.com/google/styleguide/blob/gh-pages/eclipse-java-google-style.xml) formatter. Remove the preset sorting order of import statements as shown below.
 * IntelliJ: install the google-java-format plugin.
 * VSCode: use Google's Eclipse formatter as explained [here](https://code.visualstudio.com/docs/java/java-linting#_formatter).
-* Maven: execute `mvn com.coveo:fmt-maven-plugin:format`
+* Maven: execute `mvn com.spotify.fmt:fmt-maven-plugin:format`
 
 ![image](https://user-images.githubusercontent.com/11554739/201381569-fb6afe7d-a6be-42e1-84f0-32382f0cd44b.png)


### PR DESCRIPTION
As of 2022-02-14 the plugin has moved from [coveooss](https://github.com/coveooss/fmt-maven-plugin) to the Spotify github org, and its groupId was renamed to `com.spotify.fmt`. The updated plugin works with Java 17, while the older didn't.