### PR TITLE
docs(code-style): clarify that member links are allowed

### DIFF
--- a/code-style.md
+++ b/code-style.md
@@ -76,11 +76,17 @@ The following identifiers must never be linked and should always be wrapped in `
 - Exceptions listed in the throws` clause of the documented method.
 - The names of the direct supertype and any implemented interfaces of the documented type (in a type-level comment).
 
+The restriction about which identifiers must never be linked applies only to the type identifier itself. `{@link}` must still be used for the first reference to specific methods or fields belonging to those restricted types.
+
 ```
   /**
-   * Creates a new instance of {@code FooBar}.
+   * Wraps a {@code Bar} into a new {@code Foo} container.
+   * <p>The internal name is derived via {@link Bar#getName()}. 
+   * If {@code Bar#getName()} returns {@code null}, then the internal name is randomized.
+   *
+   * @param bar the {@code Bar} instance to be wrapped
    */
-  public FooBar() { ... }
+  public Foo(Bar bar) { ... }
 ```
 
 #### Deprecation


### PR DESCRIPTION
### Clarifying the Boundary Between Type and Member Linking

#### The Problem: Algorithmic Over-Correction
Our current conventions prohibit linking to specific "restricted" types (such as argument types or the class being documented). While it is clear to a human developer that a method reference (e.g., `{@link Bar#getName()}`) is a distinct functional entity from a type reference, an LLM can easily fail to make this distinction.

Because LLMs often operate via literal pattern matching, they tend to flag the presence of a restricted identifier (like `Bar`) inside any `{@link}` tag as a violation. This leads the AI to aggressively replace necessary method links with `{@code}`.

#### The Solution: Explicit Logical Separation

By adding the note—“This restriction applies only to the type identifier itself”—we provide the explicit instruction needed for both humans and AI to understand that mandatory linking for members takes precedence over restricted types, when a member is being referenced.

#### Example of the Distinction
- The Intent: "Don't link the class name `Bar` because it's already in the method signature `Foo(Bar bar)`."
- The AI's Mistake: "Because I cannot link `Bar`, I must also not link `Bar#getName()`."
- The Correction: This update clarifies that `Bar#getName()` is a member identifier, which remains linkable on its first occurrence regardless of its parent type's status.